### PR TITLE
Fixed #31109 -- Disabled grouping by aliases on QuerySet.exists().

### DIFF
--- a/docs/releases/3.0.2.txt
+++ b/docs/releases/3.0.2.txt
@@ -11,3 +11,6 @@ Bugfixes
 
 * Fixed a regression in Django 3.0 that didn't include columns referenced by a
   ``Subquery()`` in the ``GROUP BY`` clause (:ticket:`31094`).
+
+* Fixed a regression in Django 3.0 where ``QuerySet.exists()`` crashed if a
+  queryset contained an aggregation over a ``Subquery()`` (:ticket:`31109`).

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -1141,6 +1141,16 @@ class AggregateTestCase(TestCase):
         # The GROUP BY should not be by alias either.
         self.assertEqual(ctx[0]['sql'].lower().count('latest_book_pubdate'), 1)
 
+    def test_aggregation_subquery_annotation_exists(self):
+        latest_book_pubdate_qs = Book.objects.filter(
+            publisher=OuterRef('pk')
+        ).order_by('-pubdate').values('pubdate')[:1]
+        publisher_qs = Publisher.objects.annotate(
+            latest_book_pubdate=Subquery(latest_book_pubdate_qs),
+            count=Count('book'),
+        )
+        self.assertTrue(publisher_qs.exists())
+
     @skipUnlessDBFeature('supports_subqueries_in_group_by')
     def test_group_by_subquery_annotation(self):
         """


### PR DESCRIPTION
Clearing the SELECT clause in Query.has_results was orphaning GROUP BY
references to it.

Thanks Thierry Bastian for the report and Baptiste Mispelon for the
bisect.

Regression in fb3f034f1c63160c0ff13c609acd01c18be12f80.